### PR TITLE
updated adapter sequences

### DIFF
--- a/porechop/adapters.py
+++ b/porechop/adapters.py
@@ -91,6 +91,14 @@ ADAPTERS = [Adapter('SQK-NSK007',
                     start_sequence=('PCR_1_start', 'ACTTGCCTGTCGCTCTATCTTC'),
                     end_sequence=  ('PCR_1_end', 'GAAGATAGAGCGACAGGCAAGT')),
 
+            Adapter('PCR tail 1',
+                    start_sequence=('PCR_tail_1_start', 'TTAACCTTTCTGTTGGTGCTGATATTGC'),
+                    end_sequence=  ('PCR_tail_1_end',   'GCAATATCAGCACCAACAGAAAGGTTAA')),
+
+            Adapter('PCR tail 2',
+                    start_sequence=('PCR_tail_2_start', 'TTAACCTACTTGCCTGTCGCTCTATCTTC'),
+                    end_sequence=  ('PCR_tail_2_end',   'GAAGATAGAGCGACAGGCAAGTAGGTTAA')),
+
             # Some barcoding kits (like the native barcodes) use the rev comp barcode at the start
             # of the read and the forward barcode at the end of the read.
             Adapter('Barcode 1 (reverse)',


### PR DESCRIPTION
This is the `adapters.py` we have modified to work with our libraries. However, these are based on the standard ONT PCR-based barcoding kit, and as such I thought they might be useful in the main branch. The added primer sequences share some overlap with existing adapters in the file, but are not identical. The full adapter sequences in our 1D libraries look like this (or the reverse complement):

5'-universal -> barcode -> pcr_tail_1 -> insert <- pcr_tail_2 <- barcode <- universal-3'

The universal adapter seems to be identical to the existing `SQK-NSK007`.